### PR TITLE
fixed buttonmap

### DIFF
--- a/game.libretro.mupen64plus/buttonmap.xml
+++ b/game.libretro.mupen64plus/buttonmap.xml
@@ -12,17 +12,17 @@ See also:
     <feature name="a" mapto="a"/>
     <feature name="b" mapto="b"/>
     <feature name="cup" mapto="x"/>
-    <feature name="cdown" mapto="y"/>
-    <feature name="cright" mapto="r"/>
-    <feature name="cleft" mapto="l"/>
+    <feature name="cdown" mapto="r3"/>
+    <feature name="cright" mapto="l3"/>
+    <feature name="cleft" mapto="y"/>
     <feature name="start" mapto="start"/>
     <feature name="up" mapto="up"/>
     <feature name="down" mapto="down"/>
     <feature name="right" mapto="right"/>
     <feature name="left" mapto="left"/>
-    <feature name="leftbumper" mapto="r2"/>
-    <feature name="rightbumper" mapto="l2"/>
-    <feature name="z" mapto="l3"/>
+    <feature name="leftbumper" mapto="l"/>
+    <feature name="rightbumper" mapto="r"/>
+    <feature name="z" mapto="l2"/>
     <feature name="analogstick" mapto="leftstick"/>
   </controller>
 </buttonmap>


### PR DESCRIPTION
This fixes Z-Trigger and L-R-Bumper for n64.
It also maps C-Buttons without having to press the modifier when used in conjunction with my OpenELEC repo or the fork of my libretro-mupen64plus repo:
https://github.com/a1rwulf/mupen64plus-libretro/commits/input
https://github.com/a1rwulf/OpenELEC.tv/commits/retroplayer-5.95.4
